### PR TITLE
get timestamp in miliseconds

### DIFF
--- a/src/BullPublisher.php
+++ b/src/BullPublisher.php
@@ -131,7 +131,7 @@ class BullPublisher
      */
     public function getTimestamp(): int
     {
-        return time();
+        return round(microtime(true) * 1000);
     }
 
     /**


### PR DESCRIPTION
Bull queue expects the timestamp in miliseconds, but it was being sent in seconds